### PR TITLE
fix(aws-dynamodb): Fix `addToResourcePolicy`

### DIFF
--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table-v2.ts
@@ -564,6 +564,7 @@ export class TableV2 extends TableBaseV2 {
     this.hasSortKey = props.sortKey !== undefined;
     this.region = this.stack.region;
     this.tags = new TagManager(TagType.STANDARD, CfnGlobalTable.CFN_RESOURCE_TYPE_NAME);
+    this.resourcePolicy = props.resourcePolicy;
 
     this.encryption = props.encryption;
     this.encryptionKey = this.encryption?.tableKey;
@@ -737,8 +738,8 @@ export class TableV2 extends TableBaseV2 {
     * @see https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/cx-api/FEATURE_FLAGS.md
     */
     const resourcePolicy = FeatureFlags.of(this).isEnabled(cxapi.DYNAMODB_TABLEV2_RESOURCE_POLICY_PER_REPLICA)
-      ? (props.region === this.region ? this.tableOptions.resourcePolicy : props.resourcePolicy) || undefined
-      : props.resourcePolicy ?? this.tableOptions.resourcePolicy;
+      ? (props.region === this.region ? this.tableOptions.resourcePolicy : this.resourcePolicy) || undefined
+      : this.resourcePolicy ?? this.tableOptions.resourcePolicy;
 
     const propTags: Record<string, string> = (props.tags ?? []).reduce((p, item) =>
       ({ ...p, [item.key]: item.value }), {},

--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
@@ -1207,6 +1207,8 @@ export class Table extends TableBase {
     }
     this.validateProvisioning(props);
 
+    this.resourcePolicy = props.resourcePolicy;
+
     const kinesisStreamSpecification = props.kinesisStream
       ? {
         streamArn: props.kinesisStream.streamArn,
@@ -1241,9 +1243,7 @@ export class Table extends TableBase {
       kinesisStreamSpecification: kinesisStreamSpecification,
       deletionProtectionEnabled: props.deletionProtection,
       importSourceSpecification: this.renderImportSourceSpecification(props.importSource),
-      resourcePolicy: props.resourcePolicy
-        ? { policyDocument: props.resourcePolicy }
-        : undefined,
+      resourcePolicy: Lazy.any( { produce: () => this.resourcePolicy ? { policyDocument: this.resourcePolicy } : undefined }),
       warmThroughput: props.warmThroughput?? undefined,
     });
     this.table.applyRemovalPolicy(props.removalPolicy);

--- a/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
+++ b/packages/aws-cdk-lib/aws-dynamodb/lib/table.ts
@@ -1662,8 +1662,8 @@ export class Table extends TableBase {
     const isCompleteHandlerPolicy = new SourceTableAttachedPolicy(this, provider.isCompleteHandler.role!);
 
     // Permissions in the source region
-    this.grant(onEventHandlerPolicy, 'dynamodb:*');
-    this.grant(isCompleteHandlerPolicy, 'dynamodb:DescribeTable');
+    onEventHandlerPolicy.grantPrincipal.addToPrincipalPolicy(new iam.PolicyStatement({ actions: ['dynamodb:*'], resources: [this.tableArn] }));
+    isCompleteHandlerPolicy.grantPrincipal.addToPrincipalPolicy(new iam.PolicyStatement({ actions: ['dynamodb:DescribeTable'], resources: [this.tableArn] }));
 
     let previousRegion: CustomResource | undefined;
     let previousRegionCondition: CfnCondition | undefined;

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -733,7 +733,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           alias: 'l',
           desc: 'The language to be used for the new project (default can be configured in ~/.cdk.json)',
-          choices: ['csharp', 'fsharp', 'go', 'java', 'javascript', 'python', 'typescript'],
+          choices: ['app.iml', 'csharp', 'fsharp', 'go', 'java', 'javascript', 'python', 'typescript'],
         })
         .option('list', {
           default: undefined,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -733,7 +733,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           alias: 'l',
           desc: 'The language to be used for the new project (default can be configured in ~/.cdk.json)',
-          choices: ['app.iml', 'csharp', 'fsharp', 'go', 'java', 'javascript', 'python', 'typescript'],
+          choices: ['csharp', 'fsharp', 'go', 'java', 'javascript', 'python', 'typescript'],
         })
         .option('list', {
           default: undefined,


### PR DESCRIPTION
### Issue # (if applicable)

Closes #30793.

### Reason for this change

`addToResourcePolicy` has no effect on changesets.

### Description of changes

Made `this.resourcePolicy` the target for synthesizing instead of `props.resourcePolicy`

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced ? -->

NA

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

- Added unit tests
- Tested with an existing CDK project


### Checklist
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
